### PR TITLE
Increment member count on new affiliation

### DIFF
--- a/Salud360/src/main/java/pe/edu/pucp/salud360/membresia/services/servicesImp/AfiliacionServiceImp.java
+++ b/Salud360/src/main/java/pe/edu/pucp/salud360/membresia/services/servicesImp/AfiliacionServiceImp.java
@@ -81,6 +81,7 @@ public class AfiliacionServiceImp implements AfiliacionService {
             }
         }
         c.getClientes().add(afiliacion.getCliente());
+        c.setCantMiembros(c.getCantMiembros()+1);
         comunidadRepository.save(c);
         return afiliacionMapper.mapToAfiliacionDTO(afiliacionRepository.save(afiliacion));
     }


### PR DESCRIPTION
This pull request includes a small update to the `crearAfiliacion` method in the `AfiliacionServiceImp` class. The change increments the `cantMiembros` field of a `Comunidad` object by 1 before saving it to the repository.Added logic to increase the community's member count when a new client is affiliated. This ensures the member count remains accurate after each new affiliation.